### PR TITLE
Explicitly sets encoding to UTF-8

### DIFF
--- a/Vagrant-setup/bootstrap.sh
+++ b/Vagrant-setup/bootstrap.sh
@@ -75,6 +75,9 @@ sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" "$PG_CONF"
 # Append to pg_hba.conf to add password auth:
 echo "host    all             all             all                     md5" >> "$PG_HBA"
 
+# Explicitly set default client_encoding
+echo "client_encoding = utf8" >> "$PG_CONF"
+
 # Restart so that all new config is loaded:
 service postgresql restart
 


### PR DESCRIPTION
Moving to postgres, we're trying to enforce UTF-8 encoded Unicode all the way through our stack. If this change is inappropriate for your purposes, feel free to reject it.
