### PR TITLE
Made it work again with vagrant v2.3.7 and current postgres repo structure

### DIFF
--- a/Vagrant-setup/bootstrap.sh
+++ b/Vagrant-setup/bootstrap.sh
@@ -53,10 +53,10 @@ PG_REPO_APT_SOURCE=/etc/apt/sources.list.d/pgdg.list
 if [ ! -f "$PG_REPO_APT_SOURCE" ]
 then
   # Add PG apt repo:
-  echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > "$PG_REPO_APT_SOURCE"
+  echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ trusty-pgdg main" > "$PG_REPO_APT_SOURCE"
 
   # Add PGDG repo key:
-  wget --quiet -O - https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 fi
 
 # Update package list and upgrade all packages

--- a/Vagrant-setup/bootstrap.sh
+++ b/Vagrant-setup/bootstrap.sh
@@ -31,10 +31,10 @@ print_db_usage () {
   echo "  PGUSER=$APP_DB_USER PGPASSWORD=$APP_DB_PASS psql -h localhost $APP_DB_NAME"
   echo ""
   echo "Env variable for application development:"
-  echo "  DATABASE_URL=postgresql://$APP_DB_USER:$APP_DB_PASS@localhost:15432/$APP_DB_NAME"
+  echo "  DATABASE_URL=postgresql://$APP_DB_USER:$APP_DB_PASS@localhost:5432/$APP_DB_NAME"
   echo ""
   echo "Local command to access the database via psql:"
-  echo "  PGUSER=$APP_DB_USER PGPASSWORD=$APP_DB_PASS psql -h localhost -p 15432 $APP_DB_NAME"
+  echo "  PGUSER=$APP_DB_USER PGPASSWORD=$APP_DB_PASS psql -h localhost -p 5432 $APP_DB_NAME"
 }
 
 export DEBIAN_FRONTEND=noninteractive

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,5 +18,5 @@ Vagrant::Config.run do |config|
   config.vm.provision :shell, :path => "Vagrant-setup/bootstrap.sh"
   
   # PostgreSQL Server port forwarding
-  config.vm.forward_port 5432, 15432
+  config.vm.forward_port 5432, 15432, host_ip: "127.0.0.1"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,16 +7,14 @@ date > /etc/vagrant_provisioned_at
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.provision "shell", inline: $script
-end
-
-Vagrant::Config.run do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.host_name = "postgresql" 
+  config.vm.hostname = "postgresql"
 
-  config.vm.share_folder "bootstrap", "/mnt/bootstrap", ".", :create => true
-  config.vm.provision :shell, :path => "Vagrant-setup/bootstrap.sh"
+  config.vm.synced_folder ".", "/mnt/bootstrap", create: true
   
+  config.vm.provision "shell", inline: $script
+  config.vm.provision "shell", path: "Vagrant-setup/bootstrap.sh"
+
   # PostgreSQL Server port forwarding
-  config.vm.forward_port 5432, 15432, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 5432, host: 15432, host_ip: "127.0.0.1"
 end


### PR DESCRIPTION
Some fixes were necessary to make vagrant even run with this again

- The configuration format used by vagrant changed
- The location of the postgres PGP key changed (still resides on the previous domain though)
- The files for postgres 9.4 were moved to the archive, making the links to them invalid

Lastly, I added the parameter "host_ip" to ensure that this testing env is only accessible through localhost